### PR TITLE
Remove the Interventions environment from the dev infrastructure doc

### DIFF
--- a/doc/architecture/technical-environments.md
+++ b/doc/architecture/technical-environments.md
@@ -14,14 +14,13 @@
 The first integrated environment used when developing the API service. Builds
 made via GitHub pull requests on the Delius API are automatically deployed to
 the development environment by the CircleCI build pipeline. This can then be
-used to test the API service alongside other dependent services and
-particularly alongside the user-facing nDelius application.
+used to developer test the API service alongside alongside the user-facing
+nDelius application.
 
 |                Component | Deploy Trigger     | URL                                                                                   |
 |-------------------------:|:-------------------|---------------------------------------------------------------------------------------|
 |       Delius API Service | Pull Request       | https://delius-api.dev.probation.service.justice.gov.uk                               |
 |               nDelius UI | Manual via NDST    | https://ndelius.dev.probation.service.justice.gov.uk                                  |
-| Interventions Service UI | _Undefined_        | https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk/ |
 |            Community API | Manual via Digital | https://community-api-secure.int.delius.probation.hmpps.dsd.io/                       |
 |               HMPPS-Auth | merge to `main`    | https://sign-in-dev.hmpps.service.justice.gov.uk/                                     |
 


### PR DESCRIPTION
- Removing the Interventions service from the dev environment as the infrastructure across Interventions, DPS and NDST doesn't line up
- The dev environment will be used by the Delius API team internally for development and internal integration testing
- Integrated testing and UI demos across Interventions, Community API and Delius API and Delius can only be done on merge to the `main` branch for all services