### PR TITLE
Hardcode the User ID to InterventionsServiceUser in Test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/config/AuditorAwareConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/config/AuditorAwareConfiguration.kt
@@ -11,6 +11,6 @@ import java.util.Optional
 @Service(value = "auditorAware")
 class AuditorAwareConfiguration : AuditorAware<Long> {
   override fun getCurrentAuditor(): Optional<Long> {
-    return Optional.of(8800)
+    return Optional.of(2500217590)
   }
 }


### PR DESCRIPTION
This is a temporary change to demonstrate the end-to-end interventions journey, this value will derived from the access token in future.