### PR TITLE
Use valid appointment contact type in local e2e test

### DIFF
--- a/src/e2e/resources/application-local-oracle.yml
+++ b/src/e2e/resources/application-local-oracle.yml
@@ -40,7 +40,7 @@ e2e:
       outcome: AFTA
       enforcement: ROM
     appointment:
-      type: CRSAPT
+      type: COAP
       eventId: 2500024029
       requirementId: 2500024510
       officeLocation: LDN_BCS


### PR DESCRIPTION
- CRSAPT contact type is missing an entry in R_CON_TYPE_REQ_TYPE_MAINCAT to allow for the requirement
- I think this needs to be added to the PDM for Delius to correct the data in all environments