### PR TITLE
DAPI-180 DAPI-181 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactService.kt
@@ -227,6 +227,7 @@ class ContactService(
   fun replaceContact(contactId: Long, replaceContact: ReplaceContact): ContactDto? {
     val contact = getContact(contactId)
 
+    validation.validateReplaceContactExistingContactOutcome(contact)
     validation.validateReplaceContactType(contact)
     validation.validateReplaceContactOffenderCrn(replaceContact.offenderCrn, contact)
 
@@ -245,15 +246,20 @@ class ContactService(
     val updateContact = mapper.toUpdate(contact)
 
     // 1) Get the original contact and add outcome
-    val updatedContact = updateContact.copy(outcome = replaceContact.outcome)
+    val updatedContact = mapper.toUpdate(contact).copy(
+      outcome = replaceContact.outcome
+    )
+
     updateContact(contactId, updatedContact)
 
     // 2) Create new contact based on existing one with replaced values
     val newContact = mapper.toNew(mapper.toDto(contact)).copy(
       date = replaceContact.date,
       startTime = replaceContact.startTime,
-      endTime = replaceContact.endTime
-    )
+      endTime = replaceContact.endTime,
+      outcome = null
+    ).copy(outcome = null)
+
     return createContact(newContact)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactService.kt
@@ -243,8 +243,6 @@ class ContactService(
       validation.validateReplaceContactNsiId(replaceContact.nsiId, contact)
     }
 
-    val updateContact = mapper.toUpdate(contact)
-
     // 1) Get the original contact and add outcome
     val updatedContact = mapper.toUpdate(contact).copy(
       outcome = replaceContact.outcome

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactValidationService.kt
@@ -219,4 +219,10 @@ class ContactValidationService(
       throw BadRequestException("NSI ID does not match the NSI ID on the contact")
     }
   }
+
+  fun validateReplaceContactExistingContactOutcome(contact: Contact) {
+    if (contact.outcome != null) {
+      throw BadRequestException("Contact already has an outcome and can not be replaced")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/integration/v1/contact/ReplaceContactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/integration/v1/contact/ReplaceContactTest.kt
@@ -34,7 +34,7 @@ class ReplaceContactTest : IntegrationTestBase() {
   @Transactional
   @Test
   fun `should fail if existing contact is not an attendance contact`() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST01"))
+    val existingContact = havingExistingContact(Fake.validNewContact().copy(outcome = null, type = "TST01"))
     val request = havingValidRequest(existingContact)
 
     webTestClient
@@ -46,7 +46,7 @@ class ReplaceContactTest : IntegrationTestBase() {
   @Transactional
   @Test
   fun `should fail if eventId does not match the contact eventId `() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST02"))
+    val existingContact = havingExistingContact(Fake.validNewContact().copy(outcome = null, type = "TST02"))
     val request = havingValidRequest(existingContact).copy(eventId = Fake.id())
 
     webTestClient
@@ -58,7 +58,7 @@ class ReplaceContactTest : IntegrationTestBase() {
   @Transactional
   @Test
   fun `should fail if requirement ID does not match the contact requirementId `() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST02"))
+    val existingContact = havingExistingContact(Fake.validNewContact().copy(outcome = null, type = "TST02"))
     val request = havingValidRequest(existingContact).copy(requirementId = Fake.id())
 
     webTestClient
@@ -70,7 +70,7 @@ class ReplaceContactTest : IntegrationTestBase() {
   @Transactional
   @Test
   fun `should fail if nsi ID does not match the contact NsiId `() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST02"))
+    val existingContact = havingExistingContact(Fake.validNewContact().copy(outcome = null, type = "TST02"))
     val request = havingValidRequest(existingContact).copy(nsiId = Fake.id())
 
     webTestClient
@@ -82,7 +82,7 @@ class ReplaceContactTest : IntegrationTestBase() {
   @Transactional
   @Test
   fun `should fail if offender ID does not match the contact offender ID `() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST02"))
+    val existingContact = havingExistingContact(Fake.validNewContact().copy(outcome = null, type = "TST02"))
     val request = havingValidRequest(existingContact).copy(offenderCrn = Fake.crn())
 
     webTestClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/integration/v1/contact/ReplaceContactTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/integration/v1/contact/ReplaceContactTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.deliusapi.integration.v1.contact
 
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -8,19 +9,30 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.deliusapi.dto.v1.contact.ContactDto
 import uk.gov.justice.digital.hmpps.deliusapi.dto.v1.contact.ReplaceContact
 import uk.gov.justice.digital.hmpps.deliusapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.deliusapi.repository.ContactRepository
 import uk.gov.justice.digital.hmpps.deliusapi.util.Fake
 
 @ActiveProfiles("test-h2")
 class ReplaceContactTest : IntegrationTestBase() {
 
+  @Autowired
+  lateinit var contactRepository: ContactRepository
+
   @Transactional
   @Test
   fun `should successfully create a new contact`() {
-    val existingContact = havingExistingContact(Fake.validNewContact().copy(type = "TST06"))
+    val existingContact = havingExistingContact(
+      Fake.validNewContact().copy(
+        outcome = null,
+        type = "TST06"
+      )
+    )
     val request = havingValidRequest(existingContact)
     webTestClient
       .whenReplacingContact(existingContact.id, request)
       .expectStatus().isCreated
+      .expectBody()
+      .jsonPath("$.outcome").doesNotExist()
   }
 
   private fun havingValidRequest(existingContact: ContactDto): ReplaceContact {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ContactValidationServiceTest.kt
@@ -381,6 +381,16 @@ class ContactValidationServiceTest {
     }
   }
 
+  @Test
+  fun `Replacing an attendance contact which already has an outcome should fail`() {
+    val testContact = Fake.contact()
+    testContact.type.attendanceContact = true
+    testContact.outcome = Fake.contactOutcomeType()
+    assertThrows<BadRequestException>("Contact already has an outcome and can not be replaced") {
+      subject.validateReplaceContactExistingContactOutcome(testContact)
+    }
+  }
+
   private fun attemptingToValidateContactType(
     success: Boolean,
     alert: Boolean = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ReplaceContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/deliusapi/service/contact/ReplaceContactServiceTest.kt
@@ -137,6 +137,18 @@ class ReplaceContactServiceTest : ContactServiceTestBase() {
     }
   }
 
+  @Test
+  fun `Fails when the existing contact has an outcome set`() {
+    havingDependentEntities()
+    havingMappedContacts()
+    havingRepositories()
+    havingValidation(havingNoExistingOutcome = false)
+
+    assertThrows<BadRequestException>("Contact already has an outcome and can not be replaced") {
+      whenReplacingContact()
+    }
+  }
+
   private fun havingMappedContacts(
     existingContact: Contact = Fake.contact(),
     updateContact: UpdateContact = Fake.updateContact().copy(
@@ -188,6 +200,7 @@ class ReplaceContactServiceTest : ContactServiceTestBase() {
     havingValidEventId: Boolean = true,
     havingValidRequirementId: Boolean = true,
     havingValidNsiId: Boolean = true,
+    havingNoExistingOutcome: Boolean = true,
   ) {
     val outcomeMock = whenever(validationService.validateOutcomeType(any(), any()))
 
@@ -214,6 +227,10 @@ class ReplaceContactServiceTest : ContactServiceTestBase() {
 
     if (!havingValidNsiId) {
       whenever(validationService.validateReplaceContactNsiId(any(), any())).thenThrow(BadRequestException("NSI ID does not match"))
+    }
+
+    if (!havingNoExistingOutcome) {
+      whenever(validationService.validateReplaceContactExistingContactOutcome(any())).thenThrow(BadRequestException("Contact already has an outcome and can not be replaced"))
     }
   }
 


### PR DESCRIPTION
DAPI-180 fixed outcome being set on the replacement contact
DAPI-181 Implemented validation to check for outcome on existing contact before performing the replace. Return Bad Request.